### PR TITLE
Refactor: Use embedded_hal_async::DelayNs in variegated-embassy-ads12…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,6 @@ version = "0.1.0"
 dependencies = [
  "defmt",
  "embassy-futures",
- "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "paste",

--- a/variegated-embassy-ads124s08/Cargo.toml
+++ b/variegated-embassy-ads124s08/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embassy-futures = { version = "0.1.0" }
-embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime"] }
 paste = "1.0"
 
 


### PR DESCRIPTION
…4s08

I've replaced `embassy_time` with `embedded_hal_async::DelayNs` for delay functionalities within the `variegated-embassy-ads124s08` crate.

Key changes:
- I removed `embassy-time` from dependencies.
- I updated the `ADS124S08` struct to accept and use an `impl DelayNs` for delays.
- I modified `wait_for_drdy` and `reset` methods to use the provided `DelayNs` implementation.
- The `new` function signature has been updated to include a `DelayNs` parameter. You will need to update your constructor calls when using the library.

I attempted to build, but it failed due to pre-existing issues with the `no_std` test setup in the crate. The core refactoring is complete.